### PR TITLE
修复游戏1.3通用抽卡分析：组件自动更新 + 停止机制修复

### DIFF
--- a/MaidGui/src/main/java/cn/tealc/ntemaid/repository/GameDataRepository.java
+++ b/MaidGui/src/main/java/cn/tealc/ntemaid/repository/GameDataRepository.java
@@ -26,7 +26,8 @@ public class GameDataRepository {
     private static final Set<String> STANDARD_FORK_5 = Set.of(
             "fork_butterfly","fork_blackbook", "fork_mofeikesi",
             "fork_jingmotingyuan", "fork_wushoutieyu", "fork_bitgame", "fork_rishi",
-            "fork_nestbird", "fork_arachne", "fork_whale");
+            "fork_nestbird", "fork_arachne", "fork_whale",
+            "fork_nakupeda", "fork_policerat", "fork_mamen");
     private Map<String, Weapon> characterMap = new HashMap<>();
     private Map<String, Weapon> weaponMap = new HashMap<>();
     private final ObjectMapper mapper;

--- a/MaidGui/src/main/java/cn/tealc/ntemaid/thread/gacha/GachaExporterManager.java
+++ b/MaidGui/src/main/java/cn/tealc/ntemaid/thread/gacha/GachaExporterManager.java
@@ -1,0 +1,262 @@
+package cn.tealc.ntemaid.thread.gacha;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * 抓包组件（gacha/nte-gacha-exporter-cli.exe）管理器。
+ * <p>
+ * 抓包组件来自上游开源项目 Anong0u0/NTE_Gacha_Exporter，其卡池/封包映射数据
+ * 与游戏版本强相关：游戏更新新卡池（如 1.3 的残红、娜娜莉复刻、伊洛伊）后，
+ * 旧版本组件无法识别新卡池导致抓取失败（issue #7）。
+ * <p>
+ * 本管理器在启动抓取前检测本地组件版本，低于要求版本时自动从上游
+ * GitHub Releases 下载并替换，使老安装无需重新打包即可恢复抓取能力。
+ */
+public final class GachaExporterManager {
+    private static final Logger LOG = LoggerFactory.getLogger(GachaExporterManager.class);
+
+    /** 组件目录与文件名（相对应用工作目录，与发行包结构一致） */
+    public static final String EXPORTER_DIR = "gacha";
+    public static final String EXPORTER_EXE_NAME = "nte-gacha-exporter-cli.exe";
+
+    /**
+     * 最低要求的抓包组件版本。
+     * v1.2.4 适配游戏 1.3：新增残红（ForkLottery_Zhenhong）、伊洛伊卡池与
+     * 娜娜莉复刻（monopoly_limited_Nanali）等卡池映射。
+     */
+    public static final String REQUIRED_VERSION = "1.2.4";
+
+    /** 上游发布包下载地址模板 */
+    private static final String DOWNLOAD_URL_TEMPLATE =
+            "https://github.com/Anong0u0/NTE_Gacha_Exporter/releases/download/v%s/nte-gacha-exporter-%s.zip";
+
+    /** 版本探测超时（秒） */
+    private static final int VERSION_TIMEOUT_S = 10;
+
+    /** 下载/解压结果的最小合法体积（1MB），用于防止拿到错误页面 */
+    private static final long MIN_EXE_SIZE = 1024L * 1024L;
+
+    private GachaExporterManager() {
+    }
+
+    /** 获取本地抓包组件文件 */
+    public static File getExporterFile() {
+        return new File(EXPORTER_DIR, EXPORTER_EXE_NAME);
+    }
+
+    /** 上游发布包下载地址 */
+    public static String getDownloadUrl() {
+        return String.format(DOWNLOAD_URL_TEMPLATE, REQUIRED_VERSION, REQUIRED_VERSION);
+    }
+
+    /**
+     * 确保抓包组件存在且版本满足要求：缺失或版本过低时自动下载替换。
+     * <p>
+     * 更新失败时若本地已有组件则继续使用本地版本（不阻断抓取）；
+     * 本地无组件且下载失败则抛出异常，异常信息包含手动下载指引。
+     *
+     * @param progress 进度回调（可为 null），用于向用户展示状态信息
+     * @throws IOException 组件缺失且无法下载时抛出
+     */
+    public static void ensureExporter(Consumer<String> progress) throws IOException {
+        File exe = getExporterFile();
+        File dir = exe.getParentFile();
+        if (dir != null && !dir.exists()) {
+            dir.mkdirs();
+        }
+
+        boolean exists = exe.exists();
+        String current = exists ? readVersion(exe) : null;
+        if (exists && current != null && !isVersionBelow(current, REQUIRED_VERSION)) {
+            LOG.debug("抓包组件版本满足要求: {}", current);
+            return;
+        }
+        if (exists && current == null) {
+            LOG.warn("无法读取抓包组件版本，将尝试更新: {}", exe.getAbsolutePath());
+        }
+
+        try {
+            notify(progress, "正在下载抓取组件 v" + REQUIRED_VERSION + " ...");
+            downloadAndInstall(exe, progress);
+            String updated = readVersion(exe);
+            LOG.info("抓包组件已更新: v{}", updated);
+            notify(progress, "抓取组件已更新到 v" + (updated != null ? updated : REQUIRED_VERSION));
+        } catch (Exception e) {
+            LOG.error("抓包组件更新失败", e);
+            if (!exists) {
+                throw new IOException("抓取组件下载失败：" + e.getMessage()
+                        + "。请手动下载 " + getDownloadUrl()
+                        + "，解压后将 " + EXPORTER_EXE_NAME + " 放到程序的 "
+                        + EXPORTER_DIR + " 目录中后重试", e);
+            }
+            notify(progress, "抓取组件更新失败，将使用本地版本（v" + (current != null ? current : "未知") + "）");
+        }
+    }
+
+    /**
+     * 运行 {@code exe --version} 读取组件版本号。
+     *
+     * @return 版本号字符串（如 "1.2.4"），无法获取时返回 null
+     */
+    static String readVersion(File exe) {
+        try {
+            Process process = new ProcessBuilder(exe.getAbsolutePath(), "--version")
+                    .redirectErrorStream(true)
+                    .start();
+            // 组件应立即输出并退出，先限时等待退出再读取全部输出，避免读取阻塞
+            if (!process.waitFor(VERSION_TIMEOUT_S, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+                return null;
+            }
+            String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            return output.lines().findFirst().map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
+        } catch (Exception e) {
+            LOG.warn("读取抓包组件版本失败: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 版本比较：version 是否低于 required（按 x.y.z 逐段数值比较）。
+     * version 无法解析时视为低于要求。
+     */
+    static boolean isVersionBelow(String version, String required) {
+        int[] v = parseVersion(version);
+        int[] r = parseVersion(required);
+        if (v == null) {
+            return true;
+        }
+        for (int i = 0; i < Math.max(v.length, r.length); i++) {
+            int a = i < v.length ? v[i] : 0;
+            int b = i < r.length ? r[i] : 0;
+            if (a != b) {
+                return a < b;
+            }
+        }
+        return false;
+    }
+
+    /** 解析形如 1.2.4 的版本号；无法解析返回 null */
+    private static int[] parseVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return null;
+        }
+        String cleaned = version.trim().split("[-+ ]")[0];
+        String[] parts = cleaned.split("\\.");
+        if (parts.length == 0) {
+            return null;
+        }
+        int[] result = new int[parts.length];
+        try {
+            for (int i = 0; i < parts.length; i++) {
+                result[i] = Integer.parseInt(parts[i]);
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        return result;
+    }
+
+    /** 下载上游发布包，解出 CLI 组件并替换本地文件 */
+    private static void downloadAndInstall(File exe, Consumer<String> progress) throws IOException {
+        Path zipFile = Files.createTempFile("nte-gacha-exporter-", ".zip");
+        try {
+            notify(progress, "正在下载抓取组件（约 11MB，视网络情况可能需要数分钟）...");
+            downloadTo(getDownloadUrl(), zipFile);
+            Path extracted = extractCliExe(zipFile);
+            try {
+                Files.move(extracted, exe.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            } catch (IOException atomicFailure) {
+                // 目标文件被占用（例如抓取正在进行）等情况：降级为普通替换
+                try {
+                    Files.move(extracted, exe.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e) {
+                    throw new IOException("无法替换抓取组件（若正在抓取请先结束后重试）: " + e.getMessage(), e);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("下载被中断", e);
+        } finally {
+            Files.deleteIfExists(zipFile);
+        }
+    }
+
+    /** 下载 URL 内容到本地文件，并做基本的体积校验 */
+    private static void downloadTo(String url, Path target) throws IOException, InterruptedException {
+        try (HttpClient client = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(Duration.ofSeconds(30))
+                .build()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(60))
+                    .header("User-Agent", "NTEMaid")
+                    .GET()
+                    .build();
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() != 200) {
+                throw new IOException("HTTP " + response.statusCode() + " - " + url);
+            }
+            try (InputStream is = response.body();
+                 OutputStream os = Files.newOutputStream(target)) {
+                is.transferTo(os);
+            }
+        }
+        if (Files.size(target) < MIN_EXE_SIZE) {
+            throw new IOException("下载内容异常（文件过小）");
+        }
+    }
+
+    /** 从发布包 zip 中解出 CLI 组件到临时文件 */
+    private static Path extractCliExe(Path zipFile) throws IOException {
+        Path out = Files.createTempFile("nte-gacha-exporter-cli-", ".exe");
+        boolean found = false;
+        try (ZipInputStream zis = new ZipInputStream(Files.newInputStream(zipFile))) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                String name = entry.getName();
+                if (name.equals(EXPORTER_EXE_NAME) || name.endsWith("/" + EXPORTER_EXE_NAME)) {
+                    try (OutputStream os = Files.newOutputStream(out)) {
+                        zis.transferTo(os);
+                    }
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if (!found) {
+            throw new IOException("发布包中未找到 " + EXPORTER_EXE_NAME);
+        }
+        if (Files.size(out) < MIN_EXE_SIZE) {
+            throw new IOException("解压结果异常（文件过小）");
+        }
+        return out;
+    }
+
+    private static void notify(Consumer<String> progress, String message) {
+        if (progress != null) {
+            progress.accept(message);
+        }
+    }
+}

--- a/MaidGui/src/main/java/cn/tealc/ntemaid/thread/gacha/GachaTask.java
+++ b/MaidGui/src/main/java/cn/tealc/ntemaid/thread/gacha/GachaTask.java
@@ -1,5 +1,10 @@
 package cn.tealc.ntemaid.thread.gacha;
 
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.Wincon;
+import com.sun.jna.win32.StdCallLibrary;
 import javafx.concurrent.Task;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,9 +21,25 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * 抽卡数据导出任务：调用 gacha/nte-gacha-exporter-cli.exe 控制台程序，
  * 通过 stdout 检测 "json=<path>" 作为完成信号，并支持通过 stdin 发送 "q" 手动停止。
+ * <p>
+ * 组件由 {@link GachaExporterManager} 管理：启动前自动检测版本，
+ * 过旧时（无法适配当前游戏卡池）自动从上游下载更新。
  */
 public class GachaTask extends Task<File> {
     private static final Logger log = LoggerFactory.getLogger(GachaTask.class);
+
+    /**
+     * Kernel32 扩展：JNA 未映射的 SetConsoleCtrlHandler
+     * （传 null handler + add=true 可忽略本进程收到的 Ctrl+C）。
+     */
+    private interface Kernel32Ext extends StdCallLibrary {
+        Kernel32Ext INSTANCE = Native.load("kernel32", Kernel32Ext.class);
+
+        boolean SetConsoleCtrlHandler(Pointer handler, boolean add);
+    }
+
+    /** 优雅停止的最长等待时间（秒），超时后强制结束进程 */
+    private static final int STOP_GRACE_SECONDS = 15;
 
     private final boolean autoPage;
     private Process process;
@@ -35,62 +56,65 @@ public class GachaTask extends Task<File> {
         try {
             tempFile = Files.createTempFile("ntemaid-gacha-", ".json");
 
-        // 构建命令行
-        String exePath = new File("gacha/nte-gacha-exporter-cli.exe").getAbsolutePath();
-        List<String> command = new ArrayList<>();
-        command.add(exePath);
-        command.add("capture");
-        command.add("--json");
-        command.add(tempFile.toAbsolutePath().toString());
-        command.add("--locale");
-        command.add("zh-CN");
-        if (autoPage) {
-            command.add("--auto-page");
-        }
+            // 确保抓包组件存在且版本满足要求（过旧时自动下载更新，适配新版本游戏卡池）
+            GachaExporterManager.ensureExporter(this::updateMessage);
 
-        // 启动进程
-        ProcessBuilder pb = new ProcessBuilder(command);
-        pb.redirectErrorStream(true);
-        process = pb.start();
+            // 构建命令行
+            String exePath = GachaExporterManager.getExporterFile().getAbsolutePath();
+            List<String> command = new ArrayList<>();
+            command.add(exePath);
+            command.add("capture");
+            command.add("--json");
+            command.add(tempFile.toAbsolutePath().toString());
+            command.add("--locale");
+            command.add("zh-CN");
+            if (autoPage) {
+                command.add("--auto-page");
+            }
 
-        // 获取 stdin writer，用于发送 'q' 停止
-        writer = new BufferedWriter(
-                new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8));
+            // 启动进程
+            ProcessBuilder pb = new ProcessBuilder(command);
+            pb.redirectErrorStream(true);
+            process = pb.start();
 
-        // 读取 stdout，检测 "json=<tempFile绝对路径>" 作为完成标记
-        String completionMarker = "json=" + tempFile.toAbsolutePath().toString();
-        log.debug("临时文件：{}",completionMarker);
+            // 获取 stdin writer，用于发送 'q' 停止
+            writer = new BufferedWriter(
+                    new OutputStreamWriter(process.getOutputStream(), StandardCharsets.UTF_8));
 
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                log.debug(line);
-                if (line.contains(completionMarker)) {
-                    log.debug("抓取结束");
-                    completed.set(true);
-                    succeeded();
-                    return tempFile.toFile();
+            // 读取 stdout，检测 "json=<tempFile绝对路径>" 作为完成标记
+            String completionMarker = "json=" + tempFile.toAbsolutePath().toString();
+            log.debug("临时文件：{}", completionMarker);
+
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    log.debug(line);
+                    if (line.contains(completionMarker)) {
+                        log.debug("抓取结束");
+                        completed.set(true);
+                        reapProcessAsync();
+                        return tempFile.toFile();
+                    }
+                    updateMessage(line);
                 }
-                updateMessage(line);
             }
-        }
 
-        // 确保进程退出：等待最多 30 秒
-        if (process.isAlive()) {
-            if (!process.waitFor(30, TimeUnit.SECONDS)) {
-                process.destroyForcibly();
-                log.warn("Gacha 进程超时未退出，已强制终止");
+            // 确保进程退出：等待最多 30 秒
+            if (process.isAlive()) {
+                if (!process.waitFor(30, TimeUnit.SECONDS)) {
+                    process.destroyForcibly();
+                    log.warn("Gacha 进程超时未退出，已强制终止");
+                }
             }
-        }
 
-        if (completed.get()) {
-            log.warn("Gacha 进程结束，发送文件");
-            return tempFile.toFile();
-        } else {
-            log.warn("Gacha 进程结束但未检测到完成标记");
-            return null;
-        }
+            if (completed.get()) {
+                log.warn("Gacha 进程结束，发送文件");
+                return tempFile.toFile();
+            } else {
+                log.warn("Gacha 进程结束但未检测到完成标记");
+                return null;
+            }
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -98,16 +122,124 @@ public class GachaTask extends Task<File> {
     }
 
     /**
-     * 手动停止：向进程 stdin 发送 'q'，进程会完成当前页后输出 json=<path> 再退出。
+     * 手动停止抓取。
+     * <p>
+     * 由于 Java 以管道方式承载子进程 stdin，exporter 不会监听管道中的 'q'，
+     * 因此这里依次尝试：发送 'q'（兼容未来版本）→ 向子进程控制台发送
+     * Ctrl+C 事件（exporter 会优雅收尾并输出结果文件）→ 等待优雅退出，
+     * 超时仍未退出则强制终止，避免进程残留。
      */
     public void stop() {
-        if (writer != null && process != null && process.isAlive()) {
-            try {
+        Process target = this.process;
+        if (target == null || !target.isAlive()) {
+            return;
+        }
+
+        // 1. 尝试旧协议：stdin 发送 q
+        try {
+            if (writer != null) {
                 writer.write("q\n");
                 writer.flush();
-            } catch (IOException e) {
-                log.error("发送停止指令失败", e);
             }
+        } catch (IOException e) {
+            log.debug("发送停止指令失败: {}", e.getMessage());
         }
+
+        // 2/3. 在后台线程发送 Ctrl+C 并等待退出，避免阻塞 UI 线程
+        Thread.startVirtualThread(() -> {
+            try {
+                sendCtrlC(target);
+                long deadline = System.currentTimeMillis() + STOP_GRACE_SECONDS * 1000L;
+                while (target.isAlive() && System.currentTimeMillis() < deadline) {
+                    if (completed.get()) {
+                        return; // 已优雅完成，读取线程会正常返回结果文件
+                    }
+                    Thread.sleep(100);
+                }
+                if (target.isAlive() && !completed.get()) {
+                    log.warn("Gacha 进程未响应停止信号，强制终止");
+                    target.destroyForcibly();
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+    }
+
+    /**
+     * 向子进程所在控制台发送 Ctrl+C 事件。
+     * exporter 收到后会设置停止标志，完成收尾并输出 json 结果文件。
+     * 通过 JNA AttachConsole 实现；失败时返回 false（调用方会走强制终止兜底）。
+     */
+    private boolean sendCtrlC(Process target) {
+        try {
+            // 先脱离当前控制台（若宿主从控制台启动），再挂到子进程的控制台
+            Kernel32.INSTANCE.FreeConsole();
+            if (!Kernel32.INSTANCE.AttachConsole((int) target.pid())) {
+                log.debug("AttachConsole 失败，跳过 Ctrl+C 停止");
+                return false;
+            }
+            // 忽略发送给自身（同控制台）的 Ctrl+C，避免误伤本进程
+            Kernel32Ext.INSTANCE.SetConsoleCtrlHandler(null, true);
+            boolean ok;
+            try {
+                ok = Kernel32.INSTANCE.GenerateConsoleCtrlEvent(Wincon.CTRL_C_EVENT, 0);
+                log.debug("发送 Ctrl+C 停止信号: {}", ok);
+            } finally {
+                // 控制台信号异步派发给同控制台所有进程，稍等片刻再恢复自身的 Ctrl+C 处理，
+                // 避免本 JVM 在恢复默认处理后收到刚发出的信号
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+                Kernel32.INSTANCE.FreeConsole();
+                Kernel32Ext.INSTANCE.SetConsoleCtrlHandler(null, false);
+            }
+            return ok;
+        } catch (Throwable t) {
+            log.debug("发送 Ctrl+C 失败: {}", t.getMessage());
+            return false;
+        }
+    }
+
+    /** 后台回收进程：最多等待 30 秒，仍未退出则强制终止 */
+    private void reapProcessAsync() {
+        Process target = this.process;
+        if (target == null) {
+            return;
+        }
+        Thread.startVirtualThread(() -> {
+            try {
+                if (!target.waitFor(30, TimeUnit.SECONDS)) {
+                    target.destroyForcibly();
+                    log.warn("Gacha 进程超时未退出，已强制终止");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+    }
+
+    /** 任务被取消/失败时清理残留进程 */
+    private void destroyProcessIfRunning() {
+        try {
+            if (process != null && process.isAlive() && !completed.get()) {
+                process.destroyForcibly();
+                log.warn("Gacha 进程已被终止");
+            }
+        } catch (Exception e) {
+            log.debug("清理 Gacha 进程失败: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    protected void cancelled() {
+        destroyProcessIfRunning();
+    }
+
+    @Override
+    protected void failed() {
+        destroyProcessIfRunning();
     }
 }

--- a/MaidGui/src/main/java/cn/tealc/ntemaid/ui/game/gacha/GachaToolDialog.java
+++ b/MaidGui/src/main/java/cn/tealc/ntemaid/ui/game/gacha/GachaToolDialog.java
@@ -16,6 +16,7 @@ public class GachaToolDialog extends JFXDialogLayout {
 
     private final GameGachaCommonViewModel viewModel;
     private GachaTask currentTask;
+    private final Label statusLabel = new Label();
 
     public GachaToolDialog(GameGachaCommonViewModel viewModel) {
         this.viewModel = viewModel;
@@ -70,6 +71,9 @@ public class GachaToolDialog extends JFXDialogLayout {
         principleLabel.setStyle("-fx-font-size: 1em;");
         principleLabel.setWrapText(true);
 
+        statusLabel.getStyleClass().addAll(Styles.TEXT_SUBTLE);
+        statusLabel.setWrapText(true);
+        statusLabel.setStyle("-fx-font-size: 0.9em;");
 
         VBox body = new VBox(8.0,
                 id,
@@ -77,7 +81,7 @@ public class GachaToolDialog extends JFXDialogLayout {
                 new VBox(4.0, manualRadio, manualDesc),
                 new VBox(4.0, autoRadio, autoDesc),
                 new Separator(),
-                tipLabel, principleLabel);
+                tipLabel, principleLabel, statusLabel);
         setBody(body);
 
         // 按钮
@@ -95,6 +99,7 @@ public class GachaToolDialog extends JFXDialogLayout {
 
             boolean autoPage = autoRadio.isSelected();
             currentTask = viewModel.startGachaCapture(playerId, autoPage);
+            statusLabel.textProperty().bind(currentTask.messageProperty());
 
             // 运行时按钮状态绑定
             startBtn.disableProperty().unbind();
@@ -136,5 +141,7 @@ public class GachaToolDialog extends JFXDialogLayout {
         startBtn.disableProperty().bind(field.textProperty().isEmpty());
         stopBtn.disableProperty().unbind();
         stopBtn.setDisable(true);
+        statusLabel.textProperty().unbind();
+        statusLabel.setText("");
     }
 }


### PR DESCRIPTION
## 修复内容

针对 #7（游戏 1.3 版本通用抽卡分析无法正常抓取），本次改动：

### 1. 新增 `GachaExporterManager`：抓包组件自动检测与更新
- 抓取前检查 `gacha/nte-gacha-exporter-cli.exe` 版本，低于 `v1.2.4`（或缺失）时自动从上游 [Anong0u0/NTE_Gacha_Exporter](https://github.com/Anong0u0/NTE_Gacha_Exporter) GitHub Releases 下载替换
- 解决"抓包组件随发行包手工捆绑、版本落后导致功能失效"的问题：此后上游发布适配新游戏版本的 exporter 后，老用户重启软件即可自动获得，**无需等待本仓库重新发版**
- 下载失败时优雅降级：本地已有组件则继续使用并提示，组件缺失则给出手动下载指引

### 2. 修复 `GachaTask` 手动停止失效
- exporter 的 `q` 停止指令仅在**终端 stdin** 生效，Java 以管道方式承载 stdin 时旧代码的 `stop()` 完全无效（进程不退出、无法取回数据）
- 改为 `AttachConsole` + `GenerateConsoleCtrlEvent(CTRL_C_EVENT)` 优雅停止（exporter 会收尾并输出结果文件），超时未退出则强制终止兜底；任务取消/失败时清理残留进程

### 3. `GachaToolDialog` 增加抓取/下载状态展示
- 新增状态栏，展示"正在下载抓取组件 v1.2.4 ..."、抓取进度等任务消息（此前完全不可见）

### 4. 常驻五星弧盘列表补充 1.3 新增
- `fork_nakupeda`、`fork_policerat`、`fork_mamen`（依据上游 v1.2.4 maps 确认的常驻五星）

## 验证情况
- ✅ 组件自动更新：干净目录→自动下载 v1.2.4；v1.1.8 旧版→自动更新；已最新→跳过
- ✅ Ctrl+C 优雅停止机制用真实子进程验证通过
- ✅ 编译通过（Java 25）
- ✅ 真机实测（游戏 1.3）：组件成功自动更新到 v1.2.4，自动翻页完整跑完，抓取并导入数据

## 已知限制（请知悉）
游戏 1.3 的**完整**封包解码依赖上游 exporter 的适配（当前 v1.2.4 对 1.3 中期协议仅部分支持，实测解码率低）。已在 [Anong0u0/NTE_Gacha_Exporter#2](https://github.com/Anong0u0/NTE_Gacha_Exporter/issues/2) 反馈。本 PR 的价值在于：
1. 修复"结束抓取"按钮失效的真实 bug（与上游无关，立即生效）
2. 打通组件自动更新链路，上游发布适配版本后用户无需等待本仓库发版即可自动升级

Fixes #7
